### PR TITLE
Fix a yaml parse bug

### DIFF
--- a/comparealerts/types/promrule.go
+++ b/comparealerts/types/promrule.go
@@ -12,8 +12,8 @@ import (
 type PrometheusRule struct {
 	Spec PrometheusRuleSpec `yaml:"spec,omitempty"`
 	// some times the file can directly have 'PrometheusRuleSpec' fields
-	PrometheusRuleSpec `yaml:"groups,omitempty"`
-	prOpts             *PromRuleOptions
+	PrometheusRuleSpec
+	prOpts *PromRuleOptions
 }
 type PrometheusRuleSpec struct {
 	Groups []RuleGroup `yaml:"groups,omitempty"`


### PR DESCRIPTION
Remove the tag used along with the embedded struct 'PrometheusRuleSpec'. This caused failures while parsing yaml files which starts with 'group' tag.